### PR TITLE
Pass `backCount` parameter to `$ionicNativeTransitions.goBack()` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ build/Release
 node_modules
 platforms
 plugins
+
+# Ignore IDE related files
+.idea

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -455,14 +455,31 @@ export default function() {
             }
         }
 
-        function goBack(e) {
+        /**
+         * @ngdoc function
+         * @name ionic-native-transitions.$ionicNativeTransitions#goBack
+         * @access public
+         * @methodOf ionic-native-transitions.$ionicNativeTransitions
+         * @description Navigate back in the current history stack with a back navigation transition
+         * @param {number} backCount - The number of views to go back to. default will be the previous view
+         */
+        function goBack(backCount) {
             if (!$ionicHistory.backView()) {
-                return;
+              return;
             }
+
+            // Get current history stack and find the cursor for the new view
+            // Based on the new cursor, find the new state to transition to
+            let viewHistory = $ionicHistory.viewHistory();
+            let currentHistory = viewHistory.histories[$ionicHistory.currentView().historyId];
+            let newCursor = currentHistory.cursor + backCount + 1;
+            let newState = currentHistory.stack[newCursor];
+            let stateName = newState.stateName || $ionicHistory.backView().stateName;
+
             unregisterToStateChangeStartEvent();
             let currentStateTransition = angular.extend({}, $state.current);
-            let toStateTransition = angular.extend({}, $state.get($ionicHistory.backView().stateName));
-            $ionicHistory.goBack();
+            let toStateTransition = angular.extend({}, $state.get(stateName));
+            $ionicHistory.goBack(backCount);
             transition('back', currentStateTransition, toStateTransition);
         }
     }


### PR DESCRIPTION
This change allows the method `$ionicNativeTransitions.goBack()` to pass an optional parameter `backCount` which is a number determining the number of views to go back in current history stack