### PR TITLE
Allow transitions to same state with different parameters

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -200,10 +200,12 @@ export default function () {
                 $log.debug('[native transition] cannot change state without a state...');
                 return;
             }
-            if ($state.current.name === state && !stateOptions.reload) {
+
+            if ($state.is(state, stateParams) && !stateOptions.reload) {
                 $log.debug('[native transition] same state transition are not possible');
                 return;
             }
+
             unregisterToStateChangeStartEvent();
             transition(transitionOptions);
             return $timeout(() => $state.go(state, stateParams, stateOptions));


### PR DESCRIPTION
Addresses issue raised in https://github.com/shprink/ionic-native-transitions/pull/112

Allows transitions to states with the same name, but different parameter(s), e.g.

```javascript
$ionicNativeTransitions.stateGo('detail', {
    id: 1
});

$ionicNativeTransitions.stateGo('detail', {
    id: 2
});
```

Haven't updated the dist files (it didn't seem to be generating the `.min.js` file)